### PR TITLE
fix(deps): upgrade rustpython-unparser to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "rustpython-unparser"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ac827fd0caeec3a5477654937cf8e4574482fff5bd5a259fb566c33c477fe4"
+checksum = "8e0a5e30d77fce4d71a10eef5d642da7fee071222efe5358a0079047648ccedc"
 dependencies = [
  "rustpython-ast",
  "rustpython-literal",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.24.0", features = ["extension-module"] }
 rustpython-ast = { version = "0.4.0", features = ["visitor"] }
 rustpython-parser = { version = "0.4.0" }
-rustpython-unparser = { version = "0.2.3", features = ["transformer"] }
+rustpython-unparser = { version = "0.2.4", features = ["transformer"] }

--- a/tests/test_treeshake/test_treeshake_package.py
+++ b/tests/test_treeshake/test_treeshake_package.py
@@ -192,4 +192,4 @@ def test_local_var(
     init_file = result_path / "__init__.py"
     init_file_content = init_file.read_text()
 
-    assert "(_, git_version_b, _) =" in init_file_content
+    assert "_, git_version_b, _ =" in init_file_content


### PR DESCRIPTION
new version has improved parens handling which broke flay's tests