### PR TITLE
chore: use pre-commit cargo-fmt again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
   - repo: https://github.com/AndrejOrsula/pre-commit-cargo
     rev: 0.4.0
     hooks:
+      - id: cargo-fmt
       - id: cargo-fix
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.9.9"
@@ -47,8 +48,3 @@ repos:
         language: system
         entry: .venv/bin/mypy --fast-module-lookup
         pass_filenames: false
-      - id: rustfmt
-        name: rustfmt
-        entry: rustfmt --edition 2024
-        language: rust
-        types: [rust]


### PR DESCRIPTION
pre-commit.ci has the rust toolchain version 1.85.0 in their newest runner-image