### PR TITLE
fix(renovate): make renovate manage cargo github dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,16 @@
     ":automergeMinor"
   ],
   "labels": ["dependencies"],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["Cargo.toml"],
+      "matchStrings": [
+        "{.*git.*=.*\"(?<depName>https://github.com/.+)\".*,.*tag.*=.*\"(?<currentValue>.*)\".*}",
+        "{.*tag.*=.*\"(?<currentValue>.*)\".*,.*git.*=.*\"(?<depName>https://github.com/.+)\".*}"
+      ],
+      "datasourceTemplate": "github-tags"
+    }
+  ]
 }


### PR DESCRIPTION
This should allow renovate to look for ruff crate updates