### PR TITLE
fix(renovate): use git-tags instead of github-tags

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,10 +14,10 @@
       "customType": "regex",
       "fileMatch": ["Cargo.toml"],
       "matchStrings": [
-        "{.*git.*=.*\"(?<depName>https://github.com/.+)\\.git\".*,.*tag.*=.*\"(?<currentValue>.*)\".*}",
-        "{.*tag.*=.*\"(?<currentValue>.*)\".*,.*git.*=.*\"(?<depName>https://github.com/.+)\\.git\".*}"
+        "{.*git.*=.*\"(?<depName>.+)\".*,.*tag.*=.*\"(?<currentValue>.*)\".*}",
+        "{.*tag.*=.*\"(?<currentValue>.*)\".*,.*git.*=.*\"(?<depName>.+)\".*}"
       ],
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "git-tags"
     }
   ]
 }


### PR DESCRIPTION
Renovate just cannot find the GitHub tags??? Maybe it will work with git-tags