### PR TITLE
fix(treeshake): correctly handle relative module as value imports

### DIFF
--- a/rust/src/common/ast/providers/imports_provider.rs
+++ b/rust/src/common/ast/providers/imports_provider.rs
@@ -65,10 +65,22 @@ impl ImportsTrackingProvider {
                     self.active_imports
                         .insert(asname.to_string(), format!("{}.{}", module_spec, name.name));
                 } else {
-                    self.active_imports.insert(
-                        name.name.to_string(),
-                        format!("{}.{}", module_spec, name.name),
-                    );
+                    // we probably imported a module here because the imported name was appended
+                    // to the generated module_spec already
+                    if module_spec.ends_with(name.name.as_str())
+                        && import_from
+                            .module
+                            .as_ref()
+                            .is_none_or(|x| !x.ends_with(name.name.as_str()))
+                    {
+                        self.active_imports
+                            .insert(name.name.to_string(), module_spec.to_owned());
+                    } else {
+                        self.active_imports.insert(
+                            name.name.to_string(),
+                            format!("{}.{}", module_spec, name.name),
+                        );
+                    }
                 }
             }
         }

--- a/src/flay/treeshake/package.py
+++ b/src/flay/treeshake/package.py
@@ -86,7 +86,7 @@ def treeshake_package(
         known_module_specs=known_module_specs,
     )
     references_counts |= references_counter.references_counts
-
+    log.debug("Counted references: %s", references_counts)
     # remove nodes without references
     nodes_remover = NodesRemover(references_counts, set(known_module_specs.values()))
     for file_path in file_modules:

--- a/tests/test_treeshake/packages/module_import_as_value/__init__.py
+++ b/tests/test_treeshake/packages/module_import_as_value/__init__.py
@@ -1,0 +1,9 @@
+from .class_builder import ClassBuilder
+from .submodule import example
+def main() -> None:
+    builder = ClassBuilder()
+    print(builder)
+    example.example_func()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_treeshake/packages/module_import_as_value/class_builder.py
+++ b/tests/test_treeshake/packages/module_import_as_value/class_builder.py
@@ -1,0 +1,5 @@
+from . import setters
+_DEFAULT_ON_SETATTR = setters.pipe("Hallo Welt!")
+class ClassBuilder:
+    def __init__(self) -> None:
+        self.setters = _DEFAULT_ON_SETATTR

--- a/tests/test_treeshake/packages/module_import_as_value/example2.py
+++ b/tests/test_treeshake/packages/module_import_as_value/example2.py
@@ -1,0 +1,2 @@
+def example_func2() -> None:
+    return None

--- a/tests/test_treeshake/packages/module_import_as_value/setters.py
+++ b/tests/test_treeshake/packages/module_import_as_value/setters.py
@@ -1,0 +1,2 @@
+def pipe(value: str) -> str:
+    return value

--- a/tests/test_treeshake/packages/module_import_as_value/submodule/example.py
+++ b/tests/test_treeshake/packages/module_import_as_value/submodule/example.py
@@ -1,0 +1,4 @@
+from .. import example2
+
+def example_func() -> None:
+    return example2.example_func2()

--- a/tests/test_treeshake/test_treeshake_package.py
+++ b/tests/test_treeshake/test_treeshake_package.py
@@ -161,7 +161,7 @@ def test_reference_in_comp(
     assert "_meta =" in init_file_content
 
 
-def test_global_assignment(
+def test_treeshake_package_global_assignment(
     run_treeshake_package: RunTreeshakePackageT,
 ) -> None:
     source_path = TEST_PACKAGES_DIR / "global_assignment"
@@ -184,7 +184,7 @@ def test_global_assignment(
     )
 
 
-def test_local_var(
+def test_treeshake_package_local_var(
     run_treeshake_package: RunTreeshakePackageT,
 ) -> None:
     source_path = TEST_PACKAGES_DIR / "local_var"
@@ -193,3 +193,22 @@ def test_local_var(
     init_file_content = init_file.read_text()
 
     assert "_, git_version_b, _ =" in init_file_content
+
+
+def test_treeshake_package_module_import_as_value(
+    run_treeshake_package: RunTreeshakePackageT,
+) -> None:
+    source_path = TEST_PACKAGES_DIR / "module_import_as_value"
+    result_path = run_treeshake_package(source_path)
+    class_builder_content = (result_path / "class_builder.py").read_text()
+    assert "class ClassBuilder" in class_builder_content
+    assert '_DEFAULT_ON_SETATTR = setters.pipe("Hallo Welt!")' in class_builder_content
+
+    example_file_content = (result_path / "submodule/example.py").read_text()
+    assert "def example_func() -> None:" in example_file_content
+
+    setters_file_content = (result_path / "setters.py").read_text()
+    assert "def pipe(value: str) -> str:" in setters_file_content
+
+    example2_file_content = (result_path / "example2.py").read_text()
+    assert "def example_func2() -> None:" in example2_file_content


### PR DESCRIPTION
the module name was duplicated by the imports tracker